### PR TITLE
Use Go 1.14 for building helm v3.3

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 AS helm
+FROM golang:1.14 AS helm
 RUN git -C / clone --branch v3.3.3-rancher3 --depth=1 https://github.com/rancher/helm
 RUN make -C /helm
 


### PR DESCRIPTION
This is the version that was used upstream for building:
https://github.com/helm/helm/blob/55e3ca022e40fe200fbc855938995f40b2a68ce0/.circleci/config.yml#L8