### PR TITLE
Add kustomize

### DIFF
--- a/kustomize.sh
+++ b/kustomize.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat <&0 > /home/shell/helm-run/all.yaml
+
+kustomize build . && rm /home/shell/helm-run/all.yaml

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -7,10 +7,13 @@ ARG ARCH=amd64
 RUN apk add -U curl xz
 ENV KUBECTL_VERSION v1.19.7
 ENV K9S_VERSION v0.24.14
+ENV KUSTOMIZE_VERSION v3.10.0
+ENV KUSTOMIZE_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl && \
     chmod +x kubectl
 RUN if [ "${ARCH}" = "amd64" ]; then ARCH=x86_64; fi && \
     curl -sfL https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_${ARCH}.tar.gz | tar xvzf -
+RUN curl -sLf ${KUSTOMIZE_URL} | tar -xzf - && chmod +x kustomize
 
 FROM alpine:3.12
 RUN apk add -U --no-cache bash bash-completion jq
@@ -27,7 +30,9 @@ RUN echo 'shell:x:1000:1000:shell,,,:/home/shell:/bin/bash' > /etc/passwd && \
     chmod 700 /run
 COPY --from=helm ./helm/bin/helm /usr/local/bin/
 COPY --from=build /kubectl /k9s /usr/local/bin/
+COPY --from=build ./kustomize /usr/local/bin/
 COPY package/helm-cmd package/welcome /usr/local/bin/
+COPY kustomize.sh /home/shell/
 USER 1000
 WORKDIR /home/shell
 CMD ["welcome"]

--- a/package/helm-cmd
+++ b/package/helm-cmd
@@ -15,6 +15,14 @@ for i in $(seq 1 20); do
 done
 
 for i in operation*; do
+    # If a kustomize yaml has been passed along with the operation
+    # it will have the same numerical suffix.
+    kustomization=$(echo $i.yaml | sed "s/operation/kustomization/g")
+    if [[ -f $kustomization ]]; then
+      # Renaming file because kustomize only supports the following filenames:
+      # kustomization.yaml, kustomization.yml, and Kustomization.
+      cp $kustomization kustomization.yaml
+    fi
     cat $i | xargs -0 -- echo helm
     cat $i | xargs -0 -- helm
     echo


### PR DESCRIPTION
**Problem:**
Kustomize was used in the earlier helm3 implementation. It
is necessary that it is used in an identical way on apps
that are associated with helm3 charts and were migrated
from apps.project.cattle.io. Otherwise, the absence of
comparable kustomize logic may cause manifests lacking
existing matchLabel selectors, which are immutable, to be
applied resulting in errors.

**Solution:**
Kustomize logic similar towhat was implemented before
has been added for migrated apps.

**Issue:**
https://github.com/rancher/rancher/issues/34700