### PR TITLE
Only install kustomize for amd64 and arm64

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -13,7 +13,9 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL
     chmod +x kubectl
 RUN if [ "${ARCH}" = "amd64" ]; then ARCH=x86_64; fi && \
     curl -sfL https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_${ARCH}.tar.gz | tar xvzf -
-RUN curl -sLf ${KUSTOMIZE_URL} | tar -xzf - && chmod +x kustomize
+RUN if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ]; then \
+    curl -sLf ${KUSTOMIZE_URL} | tar -xzf - && chmod +x kustomize; \
+  fi
 
 FROM alpine:3.12
 RUN apk add -U --no-cache bash bash-completion jq
@@ -29,8 +31,7 @@ RUN echo 'shell:x:1000:1000:shell,,,:/home/shell:/bin/bash' > /etc/passwd && \
     chown -R shell /home/shell && \
     chmod 700 /run
 COPY --from=helm ./helm/bin/helm /usr/local/bin/
-COPY --from=build /kubectl /k9s /usr/local/bin/
-COPY --from=build ./kustomize /usr/local/bin/
+COPY --from=build /kubectl /k9s ./kustomize /usr/local/bin/
 COPY package/helm-cmd package/welcome /usr/local/bin/
 COPY kustomize.sh /home/shell/
 USER 1000


### PR DESCRIPTION
Prior, if the arch was arm, a download of kustomize for arm would
be attempted. Kustomize does not currently support arm so the
download would fail. Now, a download will only be attempted for
amd64 and arm64. This means that kustomize will not be available
if a shell pod is on an arm node.

**Issue:**
https://github.com/rancher/rancher/issues/34700