### PR TITLE
Bump the Helm binary to v3.8.0

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4 AS helm
+FROM golang:1.17.6 AS helm
 RUN git -C / clone --branch release-v3.8.0 --depth=1 https://github.com/rancher/helm
 RUN make -C /helm
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.16.4 AS helm
-RUN git -C / clone --branch release-v3.7.0 --depth=1 https://github.com/rancher/helm
+RUN git -C / clone --branch release-v3.8.0 --depth=1 https://github.com/rancher/helm
 RUN make -C /helm
 
 FROM alpine:3.12 AS build


### PR DESCRIPTION
Bumping helm to `v3.8.0` because upstream includes a security fix for one of its dependencies.