### PR TITLE
Update k9s to use upstream and rancher/helm version

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,26 +1,19 @@
 FROM registry.suse.com/bci/golang:1.17 AS helm
 RUN zypper -n install git
-RUN git -C / clone --branch release-v3.8.0 --depth=1 https://github.com/rancher/helm
+RUN git -C / clone --branch release-v3.9.0 --depth=1 https://github.com/rancher/helm
 RUN make -C /helm
 
 FROM registry.suse.com/bci/bci-base:15.3 AS build
 ARG ARCH=amd64
 RUN zypper -n install curl gzip tar
 ENV KUBECTL_VERSION v1.21.8
-ENV K9S_VERSION v0.25.18
+ENV K9S_VERSION v0.25.19
 ENV KUSTOMIZE_VERSION v4.5.5
 ENV KUSTOMIZE_URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl && \
     chmod +x kubectl
-# We are bumping a few dependencies in K9s to fix some CVEs.
-# This is only necessary while PR https://github.com/derailed/k9s/pull/1591 is not merged upstream.
-# After the PR is merged, the below RUN command must be removed and the 2 lines after must be uncommented.
-# K9S_VERSION must be bumped too.
-RUN zypper -n install go git make && \
-    cd /tmp && git clone -b bump-deps https://github.com/macedogm/k9s.git && \
-    cd k9s && make build && chmod +x execs/k9s && mv execs/k9s /k9s
-#RUN if [ "${ARCH}" = "amd64" ]; then ARCH=x86_64; fi && \
-#    curl -sfL https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_${ARCH}.tar.gz | tar xvzf -
+RUN if [ "${ARCH}" = "amd64" ]; then ARCH=x86_64; fi && \
+    curl -sfL https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_${ARCH}.tar.gz | tar xvzf -
 RUN if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "arm64" ] || [ "${ARCH}" = "s390x" ]; then \
     curl -sLf ${KUSTOMIZE_URL} | tar -xzf - && chmod +x kustomize; \
     fi


### PR DESCRIPTION
This PR does:

- [x] Update k9s to use latest upstream version and remove the local fork used - https://github.com/derailed/k9s/releases/tag/v0.25.19
- [x] Update rancher/helm version - https://github.com/rancher/helm/pull/37