### PR TITLE
Fix broken URL in dapperfile

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,8 +5,8 @@ ENV ARCH $DAPPER_HOST_ARCH
 
 RUN zypper -n install git docker vim less file curl wget
 RUN go get golang.org/x/lint/golint && go install golang.org/x/tools/cmd/goimports@latest
-RUN if [ "${ARCH}" == "amd64" ]; then \
-        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.15.0; \
+RUN if [[ "${ARCH}" == "amd64" ]]; then \
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.46.2; \
     fi
 
 ENV GO111MODULE off


### PR DESCRIPTION
Replaces the deprecated goreleaser URL in the dapper file with the updated URL as outlined in this [task](https://github.com/rancher/tasks/issues/203)