### PR TITLE
Update Go SLE-BCI version to `1.19-2.13`

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,10 +1,10 @@
-FROM registry.suse.com/bci/golang:1.17
+FROM registry.suse.com/bci/golang:1.19-2.13
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
 RUN zypper -n install git docker vim less file curl wget
-RUN go get golang.org/x/lint/golint && go install golang.org/x/tools/cmd/goimports@latest
+RUN go install golang.org/x/lint/golint@latest && go install golang.org/x/tools/cmd/goimports@latest
 RUN if [[ "${ARCH}" == "amd64" ]]; then \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.46.2; \
     fi

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.17 AS helm
+FROM registry.suse.com/bci/golang:1.19-2.13 AS helm
 RUN zypper -n install git
 RUN git -C / clone --branch release-v3.9.0 --depth=1 https://github.com/rancher/helm
 RUN make -C /helm


### PR DESCRIPTION
Update Go SLE-BCI version to `1.19-2.13` and use the full tag version to make Dependabot bumps easier.

The `go install golang.org/x/lint/golint@latest` was updated to use `install` instead of `get`, otherwise it will break with Go 1.19. See failed [pipeline step](https://drone-pr.rancher.io/rancher/shell/96/2/2).

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>