### PR TITLE
Add bash_completion the the `k` alias

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -29,6 +29,7 @@ RUN echo 'shell:x:1000:1000:shell,,,:/home/shell:/bin/bash' > /etc/passwd && \
     echo 'alias k="kubectl"' >> /home/shell/.bashrc && \
     echo 'alias ks="kubectl -n kube-system"' >> /home/shell/.bashrc && \
     echo 'source <(kubectl completion bash)' >> /home/shell/.bashrc && \
+    echo 'complete -o default -F __start_kubectl k' >> /home/shell/.bashrc && \
     echo 'PS1="> "' >> /home/shell/.bashrc && \
     mkdir /home/shell/.kube && \
     chown -R shell /home/shell && \


### PR DESCRIPTION
we currently enable bash autocompletion for `kubectl` but not the corresponding `k` alias. I am lazy, so I extended the autocompletion to the alias as well. 