### PR TITLE
Cleanup dapper and add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @rancher/rancher-team-1-neo-dev

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,20 +1,14 @@
-FROM registry.suse.com/bci/golang:1.19-19.12
+FROM registry.suse.com/bci/bci-base:15.4.27.14.27
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
-RUN zypper -n install git docker vim less file curl wget
-RUN go install golang.org/x/lint/golint@latest && go install golang.org/x/tools/cmd/goimports@latest
-RUN if [[ "${ARCH}" == "amd64" ]]; then \
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.46.2; \
-    fi
+RUN zypper -n install docker git
 
-ENV GO111MODULE off
 ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS
-ENV DAPPER_SOURCE /go/src/github.com/rancher/shell/
+ENV DAPPER_SOURCE /shell
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
-ENV GOPATH /go
 ENV HOME ${DAPPER_SOURCE}
 WORKDIR ${DAPPER_SOURCE}
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ TARGETS := $(shell ls scripts)
 $(TARGETS): .dapper
 	./.dapper $@
 
-.DEFAULT_GOAL := default
+.DEFAULT_GOAL := ci
 
 .PHONY: $(TARGETS)

--- a/scripts/default
+++ b/scripts/default
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-cd $(dirname $0)
-
-./package


### PR DESCRIPTION
* The repository's Dapper setup seems to indicate we are building a Golang binary, but we are not as that is done in a stage in `package/Dockerfile` for Helm. So I removed all unneeded Golang settings/tools from Dapper.
* The `default` make target is confusing and unneeded, changed this to `ci`.
* Added `CODEOWNERS` as all repositories should have it