### PR TITLE
Bump rancher/helm to v3.11.1

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.suse.com/bci/golang:1.19-20.13 AS helm
 RUN zypper -n install git
-RUN git -C / clone --branch release-v3.9.0 --depth=1 https://github.com/rancher/helm
+RUN git -C / clone --branch release-v3.11.1 --depth=1 https://github.com/rancher/helm
 RUN make -C /helm
 
 FROM registry.suse.com/bci/bci-base:15.4.27.14.34 AS build


### PR DESCRIPTION
Depends on branch `release-v3.10.3` being created at https://github.com/rancher/helm.

This was tested against [rancher-3.10.3](https://github.com/pjbgf/helm/commits/rancher-3.10.3) which was created by:
- Checkout branch [v3.10.3-fleet](https://github.com/rancher/helm/tree/v3.10.3-fleet)
- Rebase from upstream
- Add cherry pick  https://github.com/rancher/helm/pull/32/commits/01637966cf892a3fb95a424f0722be413ec0158d