### PR TITLE
Restrict drone to run on pull_request and tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,10 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    event:
+    - pull_request
+    - tag
 
 - name: docker-publish
   image: plugins/docker
@@ -30,9 +34,6 @@ steps:
   when:
     instance:
     - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
     event:
     - tag
 
@@ -57,6 +58,10 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    event:
+    - pull_request
+    - tag
 
 - name: docker-publish
   image: plugins/docker
@@ -73,9 +78,6 @@ steps:
   when:
     instance:
     - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
     event:
     - tag
 
@@ -104,6 +106,10 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    event:
+    - pull_request
+    - tag
 
 - name: docker-publish
   image: rancher/drone-images:docker-s390x
@@ -123,9 +129,6 @@ steps:
   when:
     instance:
     - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
     event:
     - tag
 
@@ -159,9 +162,6 @@ steps:
   when:
     instance:
     - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
     event:
     - tag
 


### PR DESCRIPTION
With tooling that is creating PRs from branches from the repository itself, it creates a push event to Drone to start builds on `drone-publish` while thats not needed. This restricts the builds to either `pull_request` or `tag`, the rest shouldn't be needed to be build. This should also remove the build after a merge (which is another push).

I am not 100% sure on how the webhooks and Drone will respond, so this is a first attempt. If this doesn't work, we can restrict Drone further in the configuration.