### PR TITLE
Restrict embedded kubectl to <1.25

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,13 @@
   "baseBranches": [
     "master"
   ],
-  "prHourlyLimit": 2
+  "prHourlyLimit": 2,
+  "packageRules": [
+    {
+      "matchDepNames": [
+        "kubernetes/kubernetes"
+      ],
+      "allowedVersions": "<1.25.0"
+    }
+  ]
 }


### PR DESCRIPTION
Our global configuration restricts to `<1.26.0` but the embedded kubectl needs to be `<1.25.0` for now