### PR TITLE
Bump kubectl version restriction to <1.26.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
       "matchDepNames": [
         "kubernetes/kubernetes"
       ],
-      "allowedVersions": "<1.25.0"
+      "allowedVersions": "<1.26.0"
     }
   ]
 }


### PR DESCRIPTION
Bump kubectl version up one minor version for https://github.com/rancher/rancher/issues/41113