### PR TITLE
Update rancher base image

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4.27.14.60
+FROM registry.suse.com/bci/bci-base:15.4.27.14.65
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH


### PR DESCRIPTION
Updating the base image resolves the following CVEs because the base image has the curl update:
```
┌──────────┬─────────────────────┬──────────┬──────────────────────┬─────────────────────┬──────────────────────────┐
│ Library  │    Vulnerability    │ Severity │  Installed Version   │    Fixed Version    │          Title           │
├──────────┼─────────────────────┼──────────┼──────────────────────┼─────────────────────┼──────────────────────────┤
│ curl     │ SUSE-SU-2023:2224-1 │ HIGH     │ 7.79.1-150400.5.18.1 │ 8.0.1-150400.5.23.1 │ Security update for curl │
├──────────┤                     │          │                      │                     │                          │
│ libcurl4 │                     │          │                      │                     │                          │
└──────────┴─────────────────────┴──────────┴──────────────────────┴─────────────────────┴──────────────────────────┘

```