### PR TITLE
[v1.28] Update helm to v3.13.3

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,4 +1,4 @@
-HELM_VERSION := release-v3.12.3
+HELM_VERSION := v3.13.3-rancher1
 
 KUBECTL_VERSION := v1.26.9
 # curl -L "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/arm64/kubectl.sha256"


### PR DESCRIPTION
### Update
* Update helm to `v3.13.3`

### Waiting on
* https://github.com/rancher/helm/pull/43

### Related
* https://github.com/rancher/rancher/issues/43109