### PR TITLE
build: Fix renovate for kubectl and kustomize

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -2,12 +2,9 @@
 HELM_VERSION := v3.13.3-rancher1
 
 KUBECTL_VERSION := v1.26.9
-# curl -L "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/arm64/kubectl.sha256"
-KUBECTL_SUM_arm64 := f945c63220b393ddf8df67d87e67ff74b7f56219a670dee38bc597a078588e90
-# curl -L "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl.sha256"
-KUBECTL_SUM_amd64 := 98ea4a13895e54ba24f57e0d369ff6be0d3906895305d5390197069b1da12ae2
-# curl -L "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/s390x/kubectl.sha256"
-KUBECTL_SUM_s390x := 6c3f1cac8d70286eb4a661d783558101b9e4891e7997f744183506466a03625f
+KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl.sha256")
+KUBECTL_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl.sha256")
+KUBECTL_SUM_s390x ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/s390x/kubectl.sha256")
 
 # renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize
 KUSTOMIZE_VERSION := v5.3.0

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -11,11 +11,11 @@ KUBECTL_SUM_s390x := 6c3f1cac8d70286eb4a661d783558101b9e4891e7997f744183506466a0
 
 # renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize
 KUSTOMIZE_VERSION := v5.3.0
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize digestVersion=v0.31.7
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize digestVersion=v5.3.0
 KUSTOMIZE_SUM_arm64 := a1ec622d4adeb483e3cdabd70f0d66058b1e4bcec013c4f74f370666e1e045d8
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize digestVersion=v0.31.7
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize digestVersion=v5.3.0
 KUSTOMIZE_SUM_amd64 := 3ab32f92360d752a2a53e56be073b649abc1e7351b912c0fb32b960d1def854c
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize digestVersion=v0.31.7
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize digestVersion=v5.3.0
 KUSTOMIZE_SUM_s390x := 0b1a00f0e33efa2ecaa6cda9eeb63141ddccf97a912425974d6b65e66cf96cd4
 
 # renovate: datasource=github-release-attachments depName=derailed/k9s


### PR DESCRIPTION
Unfortunately, the current `renovate-config` does not support the sourcing of digests for 
`kubectl`. To bypass this limitation while keeping the auto bumps working, the digest will
be sourced on demand based on the `dl.k8s.io` endpoint.