### PR TITLE
Attempt to fix renovate config for kustomize

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -8,11 +8,11 @@ KUBECTL_SUM_s390x ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSIO
 
 # renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize
 KUSTOMIZE_VERSION := v5.3.0
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize digestVersion=v5.3.0
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize digestVersion=kustomize/v5.3.0
 KUSTOMIZE_SUM_arm64 := a1ec622d4adeb483e3cdabd70f0d66058b1e4bcec013c4f74f370666e1e045d8
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize digestVersion=v5.3.0
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize digestVersion=kustomize/v5.3.0
 KUSTOMIZE_SUM_amd64 := 3ab32f92360d752a2a53e56be073b649abc1e7351b912c0fb32b960d1def854c
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize digestVersion=v5.3.0
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize digestVersion=kustomize/v5.3.0
 KUSTOMIZE_SUM_s390x := 0b1a00f0e33efa2ecaa6cda9eeb63141ddccf97a912425974d6b65e66cf96cd4
 
 # renovate: datasource=github-release-attachments depName=derailed/k9s


### PR DESCRIPTION
Based on errors in: https://github.com/rancher/shell/actions/runs/8652126578/job/23724323843

It's trying to load:
https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/v5.3.0

but should be trying:
https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/kustomize%2Fv5.3.0 based on:
https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.3.0