### PR TITLE
renovate: Test support for module specific tags

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>rancher/renovate-config#release"
+    "github>rancher/renovate-config#modigest"
   ],
   "baseBranches": [
     "master"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: rancher/renovate-config/.github/workflows/renovate.yml@release
+    uses: rancher/renovate-config/.github/workflows/renovate.yml@modigest
     with:
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -6,13 +6,13 @@ KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSIO
 KUBECTL_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl.sha256")
 KUBECTL_SUM_s390x ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/s390x/kubectl.sha256")
 
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize/kustomize
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize extractVersion=kustomize/v(?<version>\d+\.\d+\.\d+)
 KUSTOMIZE_VERSION := v5.3.0
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize/kustomize digestVersion=v5.3.0
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize versioning=regex:^kustomize/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$ digestVersion=kustomize/v5.3.0
 KUSTOMIZE_SUM_arm64 := a1ec622d4adeb483e3cdabd70f0d66058b1e4bcec013c4f74f370666e1e045d8
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize/kustomize digestVersion=v5.3.0
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize versioning=regex:^kustomize/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$ digestVersion=kustomize/v5.3.0
 KUSTOMIZE_SUM_amd64 := 3ab32f92360d752a2a53e56be073b649abc1e7351b912c0fb32b960d1def854c
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize/kustomize digestVersion=v5.3.0
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize versioning=regex:^kustomize/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$ digestVersion=kustomize/v5.3.0
 KUSTOMIZE_SUM_s390x := 0b1a00f0e33efa2ecaa6cda9eeb63141ddccf97a912425974d6b65e66cf96cd4
 
 # renovate: datasource=github-release-attachments depName=derailed/k9s


### PR DESCRIPTION
Temporarily points to a test branch of renovate-config, this will be reverted once tests confirms the expected behaviour.