### PR TITLE
[v1.29] Update helm to v3.14.3 

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,5 +1,5 @@
 # renovate: datasource=github-release-attachments depName=rancher/helm
-HELM_VERSION := v3.13.3-rancher1
+HELM_VERSION := v3.14.3-rancher1
 
 KUBECTL_VERSION := v1.26.9
 KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl.sha256")


### PR DESCRIPTION
### Updates

- Update `HELM_VERSION`  to `v3.14.3-rancher1`

### Related

- https://github.com/rancher/rancher/issues/43110