### PR TITLE
Remove kustomize standalone binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@ clean: ## clean up project.
 test: test-build ## test the build against all target platforms.
 	$(MAKE) image-build
 	IMAGE=$(IMAGE) \
-	KUBECTL_VERSION=$(KUBECTL_VERSION) HELM_VERSION=$(HELM_VERSION) \
-	KUSTOMIZE_VERSION=$(KUSTOMIZE_VERSION) K9S_VERSION=$(K9S_VERSION) \
+	KUBECTL_VERSION=$(KUBECTL_VERSION) \
+	HELM_VERSION=$(HELM_VERSION) \
+	K9S_VERSION=$(K9S_VERSION) \
 		./hack/test
 
 test-build:

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -6,15 +6,6 @@ KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSIO
 KUBECTL_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl.sha256")
 KUBECTL_SUM_s390x ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/s390x/kubectl.sha256")
 
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize extractVersion=kustomize/v(?<version>\d+\.\d+\.\d+)
-KUSTOMIZE_VERSION := v5.4.1
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize versioning=regex:^kustomize/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$ digestVersion=kustomize/v5.4.1
-KUSTOMIZE_SUM_arm64 := 123b9ce38e04a03de5907153ef7f16979027bad16d0763a304e59dcf69ac6d30
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize versioning=regex:^kustomize/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$ digestVersion=kustomize/v5.4.1
-KUSTOMIZE_SUM_amd64 := 3d659a80398658d4fec4ec4ca184b432afa1d86451a60be63ca6e14311fc1c42
-# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kustomize versioning=regex:^kustomize/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$ digestVersion=kustomize/v5.4.1
-KUSTOMIZE_SUM_s390x := 670330c1d02b5978f63e892ce0ff26dd2efc069b82737962f74a1d07071e7ef8
-
 # renovate: datasource=github-release-attachments depName=derailed/k9s
 K9S_VERSION := v0.32.4
 # renovate: datasource=github-release-attachments depName=derailed/k9s digestVersion=v0.32.4
@@ -27,5 +18,4 @@ K9S_SUM_s390x := 29ae8a00a01a9108473dea0fd4d60e472496ec6203060f06629f402ac621175
 # Reduces the code duplication on Makefile by keeping all args into a single variable.
 IMAGE_ARGS := --build-arg HELM_VERSION=$(HELM_VERSION) \
 			  --build-arg KUBECTL_VERSION=$(KUBECTL_VERSION) --build-arg KUBECTL_SUM_arm64=$(KUBECTL_SUM_arm64) --build-arg KUBECTL_SUM_amd64=$(KUBECTL_SUM_amd64) --build-arg KUBECTL_SUM_s390x=$(KUBECTL_SUM_s390x) \
-			  --build-arg KUSTOMIZE_VERSION=$(KUSTOMIZE_VERSION) --build-arg KUSTOMIZE_SUM_arm64=$(KUSTOMIZE_SUM_arm64) --build-arg KUSTOMIZE_SUM_amd64=$(KUSTOMIZE_SUM_amd64) --build-arg KUSTOMIZE_SUM_s390x=$(KUSTOMIZE_SUM_s390x) \
 			  --build-arg K9S_VERSION=$(K9S_VERSION) --build-arg K9S_SUM_arm64=$(K9S_SUM_arm64) --build-arg K9S_SUM_amd64=$(K9S_SUM_amd64) --build-arg K9S_SUM_s390x=$(K9S_SUM_s390x)

--- a/hack/test
+++ b/hack/test
@@ -35,7 +35,6 @@ function check_files(){
     expected_file "/usr/local/bin/helm-cmd" "0:0" "755"
     expected_file "/usr/local/bin/k9s" "0:0" "755"
     expected_file "/usr/local/bin/kubectl" "0:0" "755"
-    expected_file "/usr/local/bin/kustomize" "0:0" "755"
     expected_file "/usr/local/bin/welcome" "0:0" "755"
     expected_file "/home/shell/kustomize.sh" "1000:1000" "755"
 }
@@ -62,7 +61,6 @@ function expected_version(){
 function check_versions(){
     echo "checking command versions:"
     expected_version "helm" "${HELM_VERSION}"
-    expected_version "kustomize" "${KUSTOMIZE_VERSION}"
     expected_version "k9s" "${K9S_VERSION}"
     # --client=true is used so that it does not fail trying to
     # identify the server version.

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -22,7 +22,6 @@ RUN zypper -n install curl gzip tar
 
 # Define build arguments
 ARG KUBECTL_VERSION KUBECTL_SUM_arm64 KUBECTL_SUM_amd64 KUBECTL_SUM_s390x \
-    KUSTOMIZE_VERSION KUSTOMIZE_SUM_arm64 KUSTOMIZE_SUM_amd64 KUSTOMIZE_SUM_s390x \
     K9S_VERSION K9S_SUM_arm64 K9S_SUM_amd64 K9S_SUM_s390x
 
 ARG TARGETARCH
@@ -33,12 +32,6 @@ ADD --chown=root:root --chmod=0755 \
 
 ENV KUBECTL_SUM="KUBECTL_SUM_${TARGETARCH}"
 RUN echo "${!KUBECTL_SUM}  /kubectl" | sha256sum -c -
-
-# Stage kubectl into build
-ENV KUSTOMIZE_SUM="KUSTOMIZE_SUM_${TARGETARCH}"
-RUN curl --output /tmp/kustomize.tar.gz -sLf "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz" && \
-    echo "${!KUSTOMIZE_SUM}  /tmp/kustomize.tar.gz" | sha256sum -c - && \
-    tar -xvzf /tmp/kustomize.tar.gz -C / kustomize
 
 # Stage k9s into build
 ENV K9S_SUM="K9S_SUM_${TARGETARCH}"
@@ -65,7 +58,7 @@ RUN echo 'shell:x:1000:1000:shell,,,:/home/shell:/bin/bash' > /etc/passwd && \
     chmod 700 /run
 
 COPY --chown=root:root --chmod=0755 --from=helm /helm/bin/helm /usr/local/bin/
-COPY --chown=root:root --chmod=0755 --from=build /kubectl /k9s /kustomize* /usr/local/bin/
+COPY --chown=root:root --chmod=0755 --from=build /kubectl /k9s /usr/local/bin/
 COPY --chown=root:root --chmod=0755 package/helm-cmd package/welcome /usr/local/bin/
 COPY --chown=1000:1000 --chmod=0755 package/kustomize.sh /home/shell/
 

--- a/package/kustomize.sh
+++ b/package/kustomize.sh
@@ -2,4 +2,4 @@
 
 cat <&0 > /home/shell/helm-run/all.yaml
 
-kustomize build . && rm /home/shell/helm-run/all.yaml
+kubectl kustomize . && rm /home/shell/helm-run/all.yaml


### PR DESCRIPTION
Per title, this PR removes the kustomize binary to simplify our container situation.

Sorta the goal is to _essentially_ undo: https://github.com/rancher/shell/commit/46070dcdcd0586f073dd1c4aaba89c627d607b58 . Since that was implemented back when shell had kubectl `v1.19.7` which was far earlier than kustomize was integrated into `kubectl`. However all versions of k8s that current rancher releases support require higher k8s than `1.19` so we no longer have to assume kubectl will potentially be missing kustomize.

Per the disclaimer, it's possible that this PR won't be valid for us to accept IF we require some functionality only exposed via standalone `kustomize`.

**Disclaimer:** I am not sure the full extent and context of how `kustomize` is being called within the container and across rancher. Ultimately the goal here is that ever since `kubectl` at version `1.21`+ the kustomize functionality is built into `kubectl`. It's exposed directly via `kubectl apply -k` OR `kubectl kustomize` (essentially `kustomize build`).

---
Here's a diagram showing Rancher vs shell compatibility.

```mermaid

gantt
    title All the `rancher/shell` parts VS `rancher/rancher` over k8s
    dateFormat  X
    axisFormat %s
    section Rancher
        2.7.X           :23,27
        2.8.X           :25,28
        2.9.X           :27,30
    section Kubectl
        1.23              :22,24
        1.24              :23,25
        1.25              :24,26
        1.26              :25,27
        1.27              :26,28
        1.28              :27,29
        1.29              :28,30
        1.30              :29,31
    section Kustomize
        v4.2.0          :milestone, 22,22
        v4.4.1          :milestone, 23,23
        v4.5.4          :milestone, 24,24
        v4.5.7          :25,26
        v5.0.1          :milestone, 27,27
        v5.0.4          :28,30
    section Helm
        3.10.X          :22,25
        3.11.X          :23,26
        3.12.X          :24,27
        3.13.X          :25,28
        3.14.X          :26,29
    section K9S
        v0.25.0-v0.25.18        :milestone, 22,22
        v0.25.19-v0.25.21       :milestone, 24,24
        v0.26.X                 :milestone, 25,25
        v0.27.X                 :milestone, 26,26
        v0.28.X-v0.29.X         :milestone, 28,28
        v0.30.X-v0.32.X         :milestone, 29,29
```

A good primer on how to read this - any Rancher bar indicates the k8s versions that release supports. So any cluster (local or downstream) within the Rancher setup could be any of those versions at any given time. Each index on the X axis is a k8s version minor - so for any given Rancher version, you could follow the line and identify which versions of each component would ideally be in use on that cluster when Shell is launched.

For example:
On a Rancher 2.8 cluster we open the Shell against a 1.25 k8s cluster, it will ideally use:
- Kubectl 1.25
- Kustomize 4.5.7 (standalone); ideally we can switch to built in
- Helm 3.11/3.12
- k9s 0.26

However within the same Rancher instance if we open Shell against a 1.28 cluster would be:
- Kubectl 1.28
- Kustomize 5.0.4 (standalone); ideally we can switch to built in
- Helm 3.14
- k9s 0.29.x