### PR TITLE
bump helm to v3.15.1-rancher2

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,5 +1,5 @@
 # renovate: datasource=github-release-attachments depName=rancher/helm
-HELM_VERSION := v3.14.3-rancher2
+HELM_VERSION := v3.15.1-rancher2
 
 KUBECTL_VERSION := v1.28.10
 KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl.sha256")


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/45089
- bumping helm for k8s-1.30 support