### PR TITLE
Migrate the generated image to `bci-busybox`

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,3 +1,6 @@
+ARG BCI_VERSION=15.5
+FROM registry.suse.com/bci/bci-busybox:${BCI_VERSION} as final
+
 # Image that provides cross compilation tooling.
 FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.3.0 as xx
 
@@ -46,24 +49,40 @@ RUN curl --output /tmp/k9s.tar.gz -sLf "https://github.com/derailed/k9s/releases
     echo "${!K9S_SUM}  /tmp/k9s.tar.gz" | sha256sum -c - && \
     tar -xvzf /tmp/k9s.tar.gz -C / k9s 
 
-FROM registry.suse.com/bci/bci-base:15.5 as final
-RUN zypper -n update && \
-    zypper -n install bash-completion gzip jq tar unzip vim wget && \
-    zypper clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* /usr/share/doc/manual/* /var/log/*
-RUN echo 'shell:x:1000:1000:shell,,,:/home/shell:/bin/bash' > /etc/passwd && \
-    echo 'shell:x:1000:' > /etc/group && \
-    mkdir /home/shell && \
-    echo '. /etc/profile.d/bash_completion.sh' >> /home/shell/.bashrc && \
-    echo 'alias k="kubectl"' >> /home/shell/.bashrc && \
-    echo 'alias ks="kubectl -n kube-system"' >> /home/shell/.bashrc && \
-    echo 'source <(kubectl completion bash)' >> /home/shell/.bashrc && \
-    echo 'complete -o default -F __start_kubectl k' >> /home/shell/.bashrc && \
-    echo 'LANG=en_US.UTF-8' >> /home/shell/.bashrc && \
-    echo 'PS1="> "' >> /home/shell/.bashrc && \
-    mkdir /home/shell/.kube && \
-    chown -R shell /home/shell && \
-    chmod 700 /run
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} as zypper
 
+# Creates the based dir for the target image, and hydrades it with the
+# original contents of the final image.
+RUN mkdir /chroot
+COPY --from=final / /chroot/
+
+# The final image does not contain zypper, --installroot is used to
+# install all artefacts within a dir (/chroot) that can then be copied
+# over to a scratch image.
+RUN zypper --non-interactive refresh && \
+    zypper --installroot /chroot -n rm busybox-vi busybox-links && \
+    zypper --installroot /chroot -n in bash-completion jq vim curl && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/etc/zypp/
+    
+
+RUN echo 'shell:x:1000:1000:shell,,,:/home/shell:/bin/bash' > /chroot/etc/passwd && \
+        echo 'shell:x:1000:' > /chroot/etc/group && \
+        mkdir /chroot/home/shell && \
+        echo '. /etc/profile.d/bash_completion.sh' >> /chroot/home/shell/.bashrc && \
+        echo 'alias k="kubectl"' >> /chroot/home/shell/.bashrc && \
+        echo 'alias ks="kubectl -n kube-system"' >> /chroot/home/shell/.bashrc && \
+        echo 'source <(kubectl completion bash)' >> /chroot/home/shell/.bashrc && \
+        echo 'complete -o default -F __start_kubectl k' >> /chroot/home/shell/.bashrc && \
+        echo 'LANG=en_US.UTF-8' >> /chroot/home/shell/.bashrc && \
+        echo 'PS1="> "' >> /chroot/home/shell/.bashrc && \
+        mkdir /chroot/home/shell/.kube && \
+        chown -R 1000:1000 /chroot/home/shell && \
+        chmod 700 /chroot/run
+
+FROM scratch
+
+COPY --from=zypper /chroot /
 COPY --chown=root:root --chmod=0755 --from=helm /helm/bin/helm /usr/local/bin/
 COPY --chown=root:root --chmod=0755 --from=build /kubectl /k9s /kustomize* /usr/local/bin/
 COPY --chown=root:root --chmod=0755 package/helm-cmd package/welcome /usr/local/bin/


### PR DESCRIPTION
The aim of this change is to decrease the long-term number of CVEs this image gets due to the decreased attack surface. As a result, the final image is 100MB lighter and does not contain the following commands:
```
agetty
basenc
blkdiscard
blockdev
cfdisk
chage
chcpu
chfn
chkconfig
chkstat
chmem
choom
chsh
col
colcrt
colrm
column
comps2solv
container-suseconnect
cracklib-unpacker
create-cracklib-dict
ctrlaltdel
delpart
diff3
dir
dircolors
dumpsolv
eject
expiry
faillock
fdformat
filesize
fillup
fincore
fips_standalone_hmac
flushb
fmt
fsfreeze
fstrim
funzip-plain
g13
g13-syshelp
gendiff
get_kernel_version
gpasswd
gpg
gpg2
gpg-agent
gpgconf
gpg-connect-agent
gpgparsemail
gpgscm
gpgsm
gpgsplit
gpgtar
gpgv
gpgv2
gpg-wks-server
gpg-zip
groupadd
groupdel
groupmod
grpck
gzexe
hardlink
hwclock
info
infocmp
installation_sources
installcheck
install-info
ionice
ipcmk
irqtop
isosize
join
kbxutil
lastb
lastlog
line
look
mergesolv
mkfs
mkfs.bfs
mkfs.cramfs
mkfs.minix
mkinfodir
newgrp
newuidmap
openssl
p11-kit
pinentry-tty
pinky
pr
prlimit
ptx
rcca-certificates
readprofile
refresh_initrd
rename
repo2solv
repo2solv.sh
repomdxml2solv
resizepart
rfkill
rpm2cpio
rpmconfigcheck
rpmdb
rpmdb2solv
rpmgraph
rpmkeys
rpmlocate
rpmmd2solv
rpmqpack
rpmquery
rpms2solv
rpmsign
rpmspec
rpmverify
rtcwake
runuser
safe-rm
safe-rmdir
scdaemon
scriptlive
sdiff
service
setterm
sfdisk
sg
sha224sum
skill
slabtop
smart_agetty
susetags2solv
swaplabel
swapoff
swapon
sysconf_addword
tabs
taskset
tload
toe
tput
trust
tset
tsort
uclampset
ul
uname26
unzip-plain
unzipsfx
unzipsfx-plain
updateinfoxml2solv
useradd
useradd.local
userdel
userdel-post.local
userdel-pre.local
usermod
uuidparse
vdir
vigr
vipw
watchgnupg
wdctl
wipefs
x86_64
yzpper
zcmp
zdiff
zdump
zegrep
zfgrep
zforce
zic
zipgrep
zipgrep-plain
zipinfo
zramctl
zypp-CheckAccessDeleted
zypper
zypp-NameReqPrv
zypp-refresh
```

The list above was generated by [comparing](https://gist.github.com/pjbgf/ca686b7be1b7ebc67eeb90c543375ac5) a local image with the previous tagged version:
```
./diff.sh rancher/shell v0.2.1-rc.4-amd64 dev
```