### PR TITLE
[CI] Adjust GHA test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on:
   push:
+    branches:
+      - master
+      - release/v2.*
   pull_request:
 
 permissions:


### PR DESCRIPTION
This change will only run tests on specific branches when pushed. But will continue to run on all PRs when those are submitted. This should reduce the duplicate test runs on jobs I've observed before.