### PR TITLE
Bump kubectl from v1.26.16 to v1.27.16

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,7 +1,7 @@
 # renovate: datasource=github-release-attachments depName=rancher/helm
 HELM_VERSION := v3.13.3-rancher1
 
-KUBECTL_VERSION := v1.26.15
+KUBECTL_VERSION := v1.27.16
 KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl.sha256")
 KUBECTL_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl.sha256")
 KUBECTL_SUM_s390x ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/s390x/kubectl.sha256")


### PR DESCRIPTION
Because master branch currently covers 2.7 and 2.8 we cannot bump higher than what 2.7 supports (1.27). And normally we should ideally stay one lower than that. 

However, because 2.7 is already EOM and will go EOL in November we can care a lot less about that requirement. Which means that we should feel pretty safe bumping this version now to improve 2.8 releases.