### PR TITLE
Correct renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,11 +10,18 @@
   "prHourlyLimit": 2,
   "packageRules": [
     {
-      "matchBaseBranches": ["main", "release/v2.8"],
+      "matchBaseBranches": ["main"],
       "matchDepNames": [
         "kubernetes/kubernetes"
       ],
       "allowedVersions": "<1.30.0"
+    },
+    {
+      "matchBaseBranches": ["release/v2.9"],
+      "matchDepNames": [
+        "kubernetes/kubernetes"
+      ],
+      "allowedVersions": "<1.29.0"
     },
     {
       "matchBaseBranches": ["release/v2.8"],


### PR DESCRIPTION
This corrects having duplicate 2.8 rules when I meant the one with main to be 2.9. And after thinking about it enough I decided we really want 2.9 to have a different rule than main.

Since main is "shell next" aka Shell that matches Rancher 2.10 essentially - so that one can have slightly higher bumps than 2.9.