### PR TITLE
Add workflow for head releases

### DIFF
--- a/.github/scripts/branch-tags.sh
+++ b/.github/scripts/branch-tags.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Function to get the previous tag
+getPreviousTag() {
+  local tagPrefix="$1"
+  # List all tags and filter ones that start with tagPrefix, sort by creation date
+  git tag --sort=-creatordate | grep "^${tagPrefix}" | head -n 1
+}
+
+# Determine if we're in a GitHub Actions environment
+if [ -n "$GITHUB_REF" ] && [ -n "$GITHUB_SHA" ]; then
+  # Use GHA environment variables
+  ref="$GITHUB_REF"
+  commitSha="${GITHUB_SHA:0:7}"
+else
+  # Fallback to local Git repo
+  if [ ! -d ".git" ]; then
+    echo "This script must be run from the root of a Git repository or GitHub Actions."
+    exit 1
+  fi
+  ref=$(git symbolic-ref HEAD)
+  commitSha=$(git rev-parse --short HEAD)
+fi
+
+branchTag=""
+branchStaticTag=""
+prevTag=""
+
+if [ "$ref" == "refs/heads/main" ]; then
+  branchTag="head"
+  branchStaticTag="main-${commitSha}"
+  prevTag=$(getPreviousTag "main-")
+elif [[ "$ref" == refs/heads/release/* ]]; then
+  version="${ref#refs/heads/release/}"  # Extract "vX.0"
+  branchTag="${version}-head"
+  branchStaticTag="${version}-head-${commitSha}"
+  prevTag=$(getPreviousTag "${version}-head-")
+else
+  echo "Unsupported branch pattern. Expected 'main' or 'release/*'."
+  exit 1
+fi
+
+# Output the results
+echo "branch_tag=${branchTag}"
+echo "branch_static_tag=${branchStaticTag}"
+echo "prev_static_tag=${prevTag}"

--- a/.github/workflows/head-build.yml
+++ b/.github/workflows/head-build.yml
@@ -1,0 +1,78 @@
+name : Branch head Prerelease Images
+
+on:
+  push:
+    branches:
+      - main
+      - release/v[0-9]+.0
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write # Upload artefacts to release.
+
+env:
+  PUBLIC_REGISTRY: docker.io
+
+jobs:
+  prebuild-env:
+    name: Prebuild needed Env vars
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository to the runner
+        uses: actions/checkout@v4
+      - name: Set Branch Tag and Other Variables
+        id: set-vars
+        run: bash ./.github/scripts/branch-tags.sh >> $GITHUB_OUTPUT
+    outputs:
+      branch_tag: ${{ steps.set-vars.outputs.branch_tag }}
+      branch_static_tag: ${{ steps.set-vars.outputs.branch_static_tag }}
+      prev_tag: ${{ steps.set-vars.outputs.prev_tag }}
+
+  publish-public:
+    permissions:
+      contents: read
+      # write is needed for:
+      # - OIDC for cosign's use in ecm-distro-tools/publish-image.
+      # - Read vault secrets in rancher-eio/read-vault-secrets.
+      id-token: write
+
+    runs-on: ubuntu-latest
+    needs:
+      - prebuild-env
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Load Secrets from Vault
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+
+      - name: Build and push all image variations
+        uses: rancher/ecm-distro-tools/actions/publish-image@master
+        with:
+          image: ${{ vars.IMAGE_NAME || 'shell' }}
+          tag: ${{ needs.prebuild-env.outputs.branch_static_tag }}
+          platforms: "linux/amd64,linux/arm64"
+
+          public-registry: ${{ env.PUBLIC_REGISTRY }}
+          public-repo: ${{ vars.REPO || github.repository_owner }}
+          public-username: ${{ env.DOCKER_USERNAME || vars.DOCKER_USERNAME || github.repository_owner }}
+          public-password: ${{ env.DOCKER_PASSWORD || secrets.DOCKER_PASSWORD }}
+
+          push-to-prime: false
+
+      - name: Re-tag the static head image using the rolling tag
+        env:
+          FULL_IMAGE_URL: ${{ env.PUBLIC_REGISTRY }}/${{ vars.REPO || github.repository_owner }}/${{ vars.IMAGE_NAME || 'shell' }}
+        run: |
+          VERSION="1.2.0"
+          curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz"
+          mkdir -p oras-install/
+          tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/
+          oras-install/oras copy ${{ env.FULL_IMAGE_URL }}:${{ needs.prebuild-env.outputs.branch_static_tag }} ${{ env.FULL_IMAGE_URL }}:${{ needs.prebuild-env.outputs.branch_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,6 @@ on:
     tags:
       - 'v*'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -52,7 +48,7 @@ jobs:
       uses: rancher/ecm-distro-tools/actions/publish-image@master
       with:
         image: shell
-        tag: ${{ github.ref == 'refs/heads/main' && 'head' || github.ref_name }}${{ matrix.tag-suffix }}
+        tag: ${{ github.ref_name }}${{ matrix.tag-suffix }}
         platforms: ${{ matrix.platforms }}
 
         public-registry: docker.io


### PR DESCRIPTION
Partial revert of https://github.com/rancher/shell/pull/259 to add dedicated workflow for head builds.
This one is based of semi-battle tested workflows we're using in BRO.