### PR TITLE
Add helm v3.16.1

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,5 +1,5 @@
 # renovate: datasource=github-release-attachments depName=rancher/helm
-HELM_VERSION := v3.15.1-rancher2
+HELM_VERSION := v3.16.1-rancher1
 
 KUBECTL_VERSION := v1.29.9
 KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl.sha256")


### PR DESCRIPTION
### Update

- Add helm version `v3.16.1-rancher1` 

### Related

- https://github.com/rancher/rancher/issues/46197