### PR TITLE
[v1.32] Add helm v3.17.0

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,7 +1,7 @@
 # renovate: datasource=github-release-attachments depName=rancher/helm
-HELM_VERSION := v3.16.1-rancher1
+HELM_VERSION := v3.17.0-rancher1
 
-KUBECTL_VERSION := v1.29.14
+KUBECTL_VERSION := v1.32.2
 KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl.sha256")
 KUBECTL_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl.sha256")
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.suse.com/bci/bci-busybox:${BCI_VERSION} AS final
 # Image that provides cross compilation tooling.
 FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.5.0 AS xx
 
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.22 AS helm
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.23 AS helm
 
 # Clone repository once, and reuse it for target archs.
 ARG HELM_VERSION


### PR DESCRIPTION
### Updates
- Add helm `v3.17.0`
- Bump golang to `1.23`

### Issue:
- https://github.com/rancher/rancher/issues/47934