### PR TITLE
fix: revert kubectl version bump

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,28 +15,28 @@
       "matchDepNames": [
         "kubernetes/kubernetes"
       ],
-      "allowedVersions": "<1.33.0"
+      "allowedVersions": "<1.32.0"
     },
     {
       "matchBaseBranches": ["release/v2.10"],
       "matchDepNames": [
         "kubernetes/kubernetes"
       ],
-      "allowedVersions": "<1.32.0"
+      "allowedVersions": "<1.31.0"
     },
     {
       "matchBaseBranches": ["release/v2.9"],
       "matchDepNames": [
         "kubernetes/kubernetes"
       ],
-      "allowedVersions": "<1.30.0"
+      "allowedVersions": "<1.29.0"
     },
     {
       "matchBaseBranches": ["release/v2.8"],
       "matchDepNames": [
         "kubernetes/kubernetes"
       ],
-      "allowedVersions": "<1.29.0"
+      "allowedVersions": "<1.28.0"
     }
   ]
 }

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,7 +1,7 @@
 # renovate: datasource=github-release-attachments depName=rancher/helm
 HELM_VERSION := v3.17.0-rancher1
 
-KUBECTL_VERSION := v1.32.2
+KUBECTL_VERSION := v1.31.6
 KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl.sha256")
 KUBECTL_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl.sha256")
 


### PR DESCRIPTION
Because k8s has a +-1 policy we need to target the middle version of the kubectl versions that a given Rancher supports.
This change reverts the renovate config change I errantly made and also the bump that was made by helm team.