### PR TITLE
bump: increment kubectl to 1.32 for k8s range rancher 2.12 will use

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,7 +1,7 @@
 # renovate: datasource=github-release-attachments depName=rancher/helm
 HELM_VERSION := v3.17.0-rancher1
 
-KUBECTL_VERSION := v1.31.7
+KUBECTL_VERSION := v1.32.3
 KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl.sha256")
 KUBECTL_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl.sha256")
 


### PR DESCRIPTION
Per title this is just getting ahead of the progress we normally make when the "k8s support" issues are made en mass.