### PR TITLE
Update kubectl to use renovate syntax for updates

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,9 +1,12 @@
 # renovate: datasource=github-release-attachments depName=rancher/helm
 HELM_VERSION := v3.18.3-rancher1
 
+# renovate-local: kubectl-amd64
 KUBECTL_VERSION := v1.33.1
-KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/arm64/kubectl.sha256")
-KUBECTL_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl.sha256")
+# renovate-local: kubectl-arm64=v1.33.1
+KUBECTL_SUM_arm64 := d595d1a26b7444e0beb122e25750ee4524e74414bbde070b672b423139295ce6
+# renovate-local: kubectl-amd64=v1.33.1
+KUBECTL_SUM_amd64 := 5de4e9f2266738fd112b721265a0c1cd7f4e5208b670f811861f699474a100a3
 
 # renovate-local: kustomize-amd64
 KUSTOMIZE_VERSION := v5.6.0


### PR DESCRIPTION
Implements the renovate rules from: https://github.com/rancher/renovate-config/issues/244