### PR TITLE
fix: Use the upstream version of Helm instead of Rancher fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ IMAGE = $(REPO)/shell:$(TAG)
 BUILD_ACTION = --load
 
 .DEFAULT_GOAL := ci
-ci: test validate e2e ## run the targets needed to validate a PR in CI.
+ci: test validate ## run the targets needed to validate a PR in CI.
 
 clean: ## clean up project.
 	rm -rf build

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,5 +1,9 @@
-# renovate: datasource=github-release-attachments depName=rancher/helm
-HELM_VERSION := v3.20.0-rancher1
+# renovate: datasource=github-release-attachments depName=helm/helm
+HELM_VERSION := v3.20.1
+# renovate: datasource=github-release-attachments depName=helm/helm digestVersion=v3.20.1
+HELM_SUM_arm64 := 56b9d1b0e0efbb739be6e68a37860ace8ec9c7d3e6424e3b55d4c459bc3a0401
+# renovate: datasource=github-release-attachments depName=helm/helm digestVersion=v3.20.1
+HELM_SUM_amd64 := 0165ee4a2db012cc657381001e593e981f42aa5707acdd50658326790c9d0dc3
 
 # renovate-local: kubectl-amd64
 KUBECTL_VERSION := v1.35.2
@@ -23,7 +27,7 @@ K9S_SUM_arm64 := d3dcc051d6be26ee911c00f583412802ebe203a189e51bc079332cb410c83b3
 K9S_SUM_amd64 := 0b697ed4aa80997f7de4deeed6f1fba73df191b28bf691b1f28d2f45fa2a9e9b
 
 # Reduces the code duplication on Makefile by keeping all args into a single variable.
-IMAGE_ARGS := --build-arg HELM_VERSION=$(HELM_VERSION) \
+IMAGE_ARGS := --build-arg HELM_VERSION=$(HELM_VERSION) --build-arg HELM_SUM_arm64=$(HELM_SUM_arm64) --build-arg HELM_SUM_amd64=$(HELM_SUM_amd64) \
 			  --build-arg KUBECTL_VERSION=$(KUBECTL_VERSION) --build-arg KUBECTL_SUM_arm64=$(KUBECTL_SUM_arm64) --build-arg KUBECTL_SUM_amd64=$(KUBECTL_SUM_amd64) \
 			  --build-arg KUSTOMIZE_VERSION=$(KUSTOMIZE_VERSION) --build-arg KUSTOMIZE_SUM_arm64=$(KUSTOMIZE_SUM_arm64) --build-arg KUSTOMIZE_SUM_amd64=$(KUSTOMIZE_SUM_amd64) \
 			  --build-arg K9S_VERSION=$(K9S_VERSION) --build-arg K9S_SUM_arm64=$(K9S_SUM_arm64) --build-arg K9S_SUM_amd64=$(K9S_SUM_amd64)

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,30 +1,12 @@
 ARG BCI_VERSION=15.7
 FROM registry.suse.com/bci/bci-busybox:${BCI_VERSION} AS final
 
-# Image that provides cross compilation tooling.
-FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.6.1 AS xx
-
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.25 AS helm
-
-# Clone repository once, and reuse it for target archs.
-ARG HELM_VERSION
-ADD --keep-git-dir=true https://github.com/rancher/helm.git#${HELM_VERSION} /helm
-RUN cd /helm && go mod download
-
-COPY --from=xx / /
-
-# Cross-compile instead of emulating the compilation on the target arch.
-ARG TARGETPLATFORM
-RUN xx-go --wrap && mkdir -p /run/lock
-RUN make -C /helm
-
-RUN xx-verify --static /helm/bin/helm
-
 FROM --platform=$BUILDPLATFORM registry.suse.com/bci/bci-base:${BCI_VERSION} AS build
 RUN zypper -n install curl gzip tar
 
 # Define build arguments
 ARG KUBECTL_VERSION KUBECTL_SUM_arm64 KUBECTL_SUM_amd64 \
+    HELM_VERSION HELM_SUM_arm64 HELM_SUM_amd64 \
     KUSTOMIZE_VERSION KUSTOMIZE_SUM_arm64 KUSTOMIZE_SUM_amd64 \
     K9S_VERSION K9S_SUM_arm64 K9S_SUM_amd64
 
@@ -36,6 +18,13 @@ ADD --chown=root:root --chmod=0755 \
 
 ENV KUBECTL_SUM="KUBECTL_SUM_${TARGETARCH}"
 RUN echo "${!KUBECTL_SUM}  /kubectl" | sha256sum -c -
+
+# Stage helm into build
+ADD "https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz" \
+    /tmp/helm.tar.gz
+ENV HELM_SUM="HELM_SUM_${TARGETARCH}"
+RUN echo "${!HELM_SUM}  /tmp/helm.tar.gz" | sha256sum -c - && \
+    tar -xvzf /tmp/helm.tar.gz --strip-components=1 -C / "linux-${TARGETARCH}/helm"
 
 # Stage kustomize into build
 ADD "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz" \
@@ -85,8 +74,7 @@ RUN echo 'shell:x:1000:1000:shell,,,:/home/shell:/bin/bash' > /chroot/etc/passwd
 FROM scratch
 
 COPY --from=zypper /chroot /
-COPY --chown=root:root --chmod=0755 --from=helm /helm/bin/helm /usr/local/bin/
-COPY --chown=root:root --chmod=0755 --from=build /kubectl /k9s /kustomize* /usr/local/bin/
+COPY --chown=root:root --chmod=0755 --from=build /kubectl /helm /k9s /kustomize* /usr/local/bin/
 COPY --chown=root:root --chmod=0755 package/helm-cmd package/welcome /usr/local/bin/
 COPY --chown=1000:1000 --chmod=0755 package/kustomize.sh /home/shell/
 


### PR DESCRIPTION
For testing I have produced an image based on this PR as: `mallardduck/shell:63f302b`

~Note: Shell `main` branch applies to 2.14 not 2.15 yet; before we merge we should branch Shell and only merge to affect 2.15.~

Shell has been branched for 2.14 so `main` is ready for 2.15 only changes.